### PR TITLE
fix(api/product): name en vez de title en productos de API

### DIFF
--- a/Api/helpers/productHelper.js
+++ b/Api/helpers/productHelper.js
@@ -16,7 +16,7 @@ const cleanArrayProductApi = (productsApi) =>
   productsApi.map((product) => {
     return {
       id: product.id,
-      name: product.name,
+      name: product.title,
       price: product.price,
       description: product.description,
       image: product.image,


### PR DESCRIPTION
Arreglé el get de productos porque no estaba trayendo el name de los productos, era la propiedad title y no name.